### PR TITLE
Create frontend dir on module load

### DIFF
--- a/omod/src/main/java/org/openmrs/module/spa/SpaActivator.java
+++ b/omod/src/main/java/org/openmrs/module/spa/SpaActivator.java
@@ -11,19 +11,57 @@ package org.openmrs.module.spa;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.openmrs.api.AdministrationService;
+import org.openmrs.api.context.Context;
 import org.openmrs.module.BaseModuleActivator;
+import org.openmrs.module.ModuleConstants;
+import org.openmrs.module.ModuleException;
+import org.openmrs.util.OpenmrsUtil;
+
+import java.io.File;
 
 public class SpaActivator extends BaseModuleActivator {
 
 	private final Log log = LogFactory.getLog(getClass());
+	private final String FRONTENT_DIRECTORY = "frontend";
+	private final String SINGLE_SPA_STATIC_FILES_DIR = "spa.frontend.directory";
 	
 	@Override
 	public void started() {
+
+		createFrontendDirectoryInAppDirectory();
 		log.info("SPA module started");
 	}
 
 	@Override
 	public void stopped() {
 		log.info("SPA module stopped");
+	}
+
+	public void createFrontendDirectoryInAppDirectory() {
+
+		AdministrationService as = Context.getAdministrationService();
+		String folderName = as.getGlobalProperty(SINGLE_SPA_STATIC_FILES_DIR,
+				FRONTENT_DIRECTORY);
+
+		// try to load the repository folder straight away.
+		File folder = new File(folderName);
+
+		// if the property wasn't a full path already, assume it was intended to be a folder in the
+		// application directory
+		if (!folder.exists()) {
+			folder = new File(OpenmrsUtil.getApplicationDataDirectory(), folderName);
+		}
+
+		// now create the modules folder if it doesn't exist
+		if (!folder.exists()) {
+			log.warn("Frontend directory " + folder.getAbsolutePath() + " doesn't exist.  Creating it now.");
+			folder.mkdirs();
+		}
+
+		if (!folder.isDirectory())
+			throw new ModuleException("SPA frontend repository is not a directory at: " + folder.getAbsolutePath());
+
+		//return folder;
 	}
 }

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -20,6 +20,12 @@
         <defaultValue>/spa</defaultValue>
         <description>The base URL from where Single Page Applications are served</description>
     </globalProperty>
+
+    <globalProperty>
+        <property>spa.frontend.directory</property>
+        <defaultValue>frontend</defaultValue>
+        <description>The directory that holds static files for the single-spa</description>
+    </globalProperty>
     
 	<servlet>
         <servlet-name>spaServlet</servlet-name>


### PR DESCRIPTION
There is a need to create a directory in the OpenMRS app directory from where static files for single spa components will be served. The directory should have a default name of  **frontend**. This should be manageable using a global property.



