### PR TITLE
Added base tag for single spa index page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+.idea/
+omod/target/
+api/target
+api/bin/
+*.iml
+
+.project
+omod/bin/
+.vscode/

--- a/omod/src/main/java/org/openmrs/module/spa/filter/SpaFilter.java
+++ b/omod/src/main/java/org/openmrs/module/spa/filter/SpaFilter.java
@@ -23,11 +23,10 @@ import javax.servlet.http.HttpServletRequest;
 import org.apache.commons.lang3.StringUtils;
 import org.openmrs.api.context.Context;
 
+import static org.openmrs.module.util.SingleSpaConstants.DEFAULT_SPA_BASE_URL;
+import static org.openmrs.module.util.SingleSpaConstants.GP_KEY_SPA_BASE_URL;
+
 public class SpaFilter implements Filter {
-	
-	public static final String DEFAULT_SPA_BASE_URL = "/spa";
-	
-	public static final String GP_KEY_SPA_BASE_URL = "spa.baseUrl";
 
 	
 	@Override

--- a/omod/src/main/java/org/openmrs/module/spa/servlet/SpaServlet.java
+++ b/omod/src/main/java/org/openmrs/module/spa/servlet/SpaServlet.java
@@ -9,6 +9,9 @@
  */
 package org.openmrs.module.spa.servlet;
 
+import org.openmrs.api.APIException;
+import org.openmrs.api.context.Context;
+
 import java.io.IOException;
 
 import javax.servlet.RequestDispatcher;
@@ -17,6 +20,9 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import static org.openmrs.module.util.SingleSpaConstants.DEFAULT_SPA_BASE_URL;
+import static org.openmrs.module.util.SingleSpaConstants.GP_KEY_SPA_BASE_URL;
+
 public class SpaServlet extends HttpServlet {
 
 	private static final long serialVersionUID = 1L;
@@ -24,6 +30,11 @@ public class SpaServlet extends HttpServlet {
 	@Override
 	protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
 		RequestDispatcher dispatcher = req.getRequestDispatcher("/module/spa/master-single-page-application.form");
+
+		req.setAttribute("openmrsBaseUrlContext", new String(req.getContextPath()));
+		req.setAttribute("spaBaseUrlContext",
+				Context.getAdministrationService().getGlobalProperty(GP_KEY_SPA_BASE_URL, DEFAULT_SPA_BASE_URL));
+
 		dispatcher.forward(req, resp);
 	}
 }

--- a/omod/src/main/java/org/openmrs/module/util/SingleSpaConstants.java
+++ b/omod/src/main/java/org/openmrs/module/util/SingleSpaConstants.java
@@ -1,0 +1,28 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ * 
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+
+package org.openmrs.module.util;
+
+
+/**
+ * Constants used in SingleSpa Module.
+ */
+public final class SingleSpaConstants {
+
+    public static final String DEFAULT_SPA_BASE_URL = "/spa";
+	
+	public static final String GP_KEY_SPA_BASE_URL = "spa.baseUrl";
+
+
+    private SingleSpaConstants() {
+	}
+
+}
+

--- a/omod/src/main/webapp/master-single-page-application.jsp
+++ b/omod/src/main/webapp/master-single-page-application.jsp
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>OpenMRS</title>
+    <base href="${requestScope.openmrsBaseUrlContext}${requestScope.spaBaseUrlContext}${'/'}" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="importmap-type" content="systemjs-importmap">
     <link rel="preload" href="${cookie['import-map-override-url'] == null ? '/import-map.json' : cookie['import-map-override-url'].getValue()}" as="fetch" crossorigin="anonymous" />
@@ -14,7 +15,10 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/systemjs/3.1.6/extras/named-exports.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/systemjs/3.1.6/extras/named-register.min.js"></script>
     <script>
-      System.import("@openmrs/root-config")
+      window.openmrsBase= "${requestScope.openmrsBaseUrlContext}";
+      window.spaBase =  "${requestScope.spaBaseUrlContext}";
+      window.getOpenmrsSpaBase = function() { return window.openmrsBase + window.spaBase + '/';};
+      System.import("@openmrs/root-config");
     </script>
   </head>
   <body>


### PR DESCRIPTION
MF-5: The OpenMRS context and spaBasePath are server configurations that need to be specified as the "base url" for react, angular, and vue routers. 

https://issues.openmrs.org/projects/MF/issues/MF-5?filter=allopenissues