### PR TITLE
MF-3-Fix: Fix systemjs cdn url

### DIFF
--- a/omod/src/main/webapp/master-single-page-application.jsp
+++ b/omod/src/main/webapp/master-single-page-application.jsp
@@ -10,11 +10,11 @@
     <link rel="preload" href="${cookie['import-map-override-url'] == null ? '/frontend/import-map.json' : cookie['import-map-override-url'].getValue()}" as="fetch" crossorigin="anonymous" />
     <script type='systemjs-importmap' src="${cookie['import-map-override-url'] == null ? '/frontend/import-map.json' : cookie['import-map-override-url'].getValue()}"></script>
     <script src="/frontend/import-map-overrides@1.7.2/dist/import-map-overrides.min.js"></script>
-    <script src="/frontend/systemjs@4.1.0/system.min.js"></script>
-    <script src="/frontend/systemjs@4.1.0/extras/amd.min.js"></script>
-    <script src="/frontend/systemjs@4.1.0/extras/named-exports.js"></script>
-    <script src="/frontend/systemjs@4.1.0/extras/named-register.min.js"></script>
-    <script src="/frontend/systemjs@4.1.0/extras/use-default.min.js"></script>
+    <script src="/frontend/systemjs@4.1.0/dist/system.min.js"></script>
+    <script src="/frontend/systemjs@4.1.0/dist/extras/amd.min.js"></script>
+    <script src="/frontend/systemjs@4.1.0/dist/extras/named-exports.js"></script>
+    <script src="/frontend/systemjs@4.1.0/dist/extras/named-register.min.js"></script>
+    <script src="/frontend/systemjs@4.1.0/dist/extras/use-default.min.js"></script>
     <script>
       window.openmrsBase= "${requestScope.openmrsBaseUrlContext}";
       window.spaBase =  "${requestScope.spaBaseUrlContext}";


### PR DESCRIPTION
Fixed the SystemJS import urls. This is because for the [jsDelivr](https://cdn.jsdelivr.net) cdn has the required files under the dist path.