### PR TITLE
Loading styleguide

### DIFF
--- a/omod/src/main/webapp/master-single-page-application.jsp
+++ b/omod/src/main/webapp/master-single-page-application.jsp
@@ -21,6 +21,7 @@
       window.spaBase =  "${requestScope.spaBaseUrlContext}";
       window.getOpenmrsSpaBase = function() { return window.openmrsBase + window.spaBase + '/';};
       System.import("@openmrs/root-config");
+      System.import("@openmrs/styleguide");
     </script>
     <c:import url="${requestScope.spaHeadContentUrl}" />
   </head>


### PR DESCRIPTION
We won't need to add all modules into the html file, since most of them are loaded via openmrs-esm-root-config and single-spa. However, the styleguide is an exception since it needs to be loaded always for all other code to look right. So this code adds it into the html file.