### PR TITLE
Changing es modules to have the esm in their name

### DIFF
--- a/omod/src/main/webapp/master-single-page-application.jsp
+++ b/omod/src/main/webapp/master-single-page-application.jsp
@@ -20,8 +20,8 @@
       window.openmrsBase= "${requestScope.openmrsBaseUrlContext}";
       window.spaBase =  "${requestScope.spaBaseUrlContext}";
       window.getOpenmrsSpaBase = function() { return window.openmrsBase + window.spaBase + '/';};
-      System.import("@openmrs/root-config");
-      System.import("@openmrs/styleguide");
+      System.import("@openmrs/esm-root-config");
+      System.import("@openmrs/esm-styleguide");
     </script>
     <c:import url="${requestScope.spaHeadContentUrl}" />
   </head>


### PR DESCRIPTION
This change is to make the name of the module in the import map be consistent with the name of the github repos.