### PR TITLE
MF-72 Fixed /openmrs prefix issue in static resource paths

### DIFF
--- a/omod/src/main/webapp/master-single-page-application.jsp
+++ b/omod/src/main/webapp/master-single-page-application.jsp
@@ -8,16 +8,16 @@
     <base href="${requestScope.openmrsBaseUrlContext}${requestScope.spaBaseUrlContext}${'/'}" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="importmap-type" content="systemjs-importmap">
-    <link rel="preload" href="${cookie['import-map-override-url'] == null ? '/frontend/import-map.json' : cookie['import-map-override-url'].getValue()}" as="fetch" crossorigin="anonymous" />
-    <script type='systemjs-importmap' src="${cookie['import-map-override-url'] == null ? '/frontend/import-map.json' : cookie['import-map-override-url'].getValue()}"></script>
-    <script src="/frontend/import-map-overrides@1.8.0/dist/import-map-overrides.min.js"></script>
+    <link rel="preload" href="${cookie['import-map-override-url'] == null ? requestScope.openmrsBaseUrlContext.concat('/frontend/import-map.json') : cookie['import-map-override-url'].getValue()}" as="fetch" crossorigin="anonymous" />
+    <script type='systemjs-importmap' src="${cookie['import-map-override-url'] == null ? requestScope.openmrsBaseUrlContext.concat('/frontend/import-map.json') : cookie['import-map-override-url'].getValue()}"></script>
+    <script src="${requestScope.openmrsBaseUrlContext}/frontend/import-map-overrides@1.8.0/dist/import-map-overrides.min.js"></script>
     <script type="systemjs-module" src="import:@openmrs/esm-root-config"></script>
     <script type="systemjs-module" src="import:@openmrs/esm-styleguide"></script>
-    <script src="/frontend/systemjs@6.1.1/dist/system.min.js"></script>
-    <script src="/frontend/systemjs@6.1.1/dist/extras/amd.min.js"></script>
-    <script src="/frontend/systemjs@6.1.1/dist/extras/named-exports.js"></script>
-    <script src="/frontend/systemjs@6.1.1/dist/extras/named-register.min.js"></script>
-    <script src="/frontend/systemjs@6.1.1/dist/extras/use-default.min.js"></script>
+    <script src="${requestScope.openmrsBaseUrlContext}/frontend/systemjs@6.1.1/dist/system.min.js"></script>
+    <script src="${requestScope.openmrsBaseUrlContext}/frontend/systemjs@6.1.1/dist/extras/amd.min.js"></script>
+    <script src="${requestScope.openmrsBaseUrlContext}/frontend/systemjs@6.1.1/dist/extras/named-exports.js"></script>
+    <script src="${requestScope.openmrsBaseUrlContext}/frontend/systemjs@6.1.1/dist/extras/named-register.min.js"></script>
+    <script src="${requestScope.openmrsBaseUrlContext}/frontend/systemjs@6.1.1/dist/extras/use-default.min.js"></script>
     <script>
       window.openmrsBase= "${requestScope.openmrsBaseUrlContext}";
       window.spaBase =  "${requestScope.spaBaseUrlContext}";


### PR DESCRIPTION
Fixed MF-72 by prefixing requestScope.openmrsBaseUrlContext in the static resource urls 