### PR TITLE
MF-73 import-map-overrides is not minified, but module-spa HTML expects .min file

### DIFF
--- a/omod/src/main/webapp/master-single-page-application.jsp
+++ b/omod/src/main/webapp/master-single-page-application.jsp
@@ -10,7 +10,7 @@
     <meta name="importmap-type" content="systemjs-importmap">
     <link rel="preload" href="${cookie['import-map-override-url'] == null ? requestScope.openmrsBaseUrlContext.concat('/frontend/import-map.json') : cookie['import-map-override-url'].getValue()}" as="fetch" crossorigin="anonymous" />
     <script type='systemjs-importmap' src="${cookie['import-map-override-url'] == null ? requestScope.openmrsBaseUrlContext.concat('/frontend/import-map.json') : cookie['import-map-override-url'].getValue()}"></script>
-    <script src="${requestScope.openmrsBaseUrlContext}/frontend/import-map-overrides@1.8.0/dist/import-map-overrides.min.js"></script>
+    <script src="${requestScope.openmrsBaseUrlContext}/frontend/import-map-overrides@1.8.0/dist/import-map-overrides.js"></script>
     <script type="systemjs-module" src="import:@openmrs/esm-root-config"></script>
     <script type="systemjs-module" src="import:@openmrs/esm-styleguide"></script>
     <script src="${requestScope.openmrsBaseUrlContext}/frontend/systemjs@6.1.1/dist/system.min.js"></script>


### PR DESCRIPTION
https://issues.openmrs.org/projects/MF/issues/MF-73

import-map-overrides does not provide a .min file.