### PR TITLE
Change root config with an OpenMRS setting

### DIFF
--- a/omod/src/main/java/org/openmrs/module/spa/servlet/SpaServlet.java
+++ b/omod/src/main/java/org/openmrs/module/spa/servlet/SpaServlet.java
@@ -33,6 +33,8 @@ public class SpaServlet extends HttpServlet {
 		req.setAttribute("openmrsBaseUrlContext", new String(req.getContextPath()));
 		req.setAttribute("spaBaseUrlContext",
 				Context.getAdministrationService().getGlobalProperty(GP_KEY_SPA_BASE_URL, DEFAULT_SPA_BASE_URL));
+		req.setAttribute("spaRootConfig",
+				Context.getAdministrationService().getGlobalProperty(GP_ROOT_CONFIG, DEFAULT_ROOT_CONFIG));
 		req.setAttribute("spaHeadContentUrl",
 				Context.getAdministrationService().getGlobalProperty(GP_HEAD_CONTENT_URL, null));
 		req.setAttribute("spaBodyContentUrl",

--- a/omod/src/main/java/org/openmrs/module/util/SingleSpaConstants.java
+++ b/omod/src/main/java/org/openmrs/module/util/SingleSpaConstants.java
@@ -17,8 +17,12 @@ package org.openmrs.module.util;
 public final class SingleSpaConstants {
 
     public static final String DEFAULT_SPA_BASE_URL = "/spa";
-	
+
 	public static final String GP_KEY_SPA_BASE_URL = "spa.baseUrl";
+
+	public static final String DEFAULT_ROOT_CONFIG = "@openmrs/esm-root-config";
+
+	public static final String GP_ROOT_CONFIG = "spa.rootConfig";
 
 	public static final String GP_BODY_CONTENT_URL = "spa.bodyContentUrl";
 

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -22,6 +22,12 @@
     </globalProperty>
 
     <globalProperty>
+        <property>spa.rootConfig</property>
+        <defaultValue>@openmrs/esm-root-config</defaultValue>
+        <description>The SPA root config ESM</description>
+    </globalProperty>
+
+    <globalProperty>
         <property>spa.headContentUrl</property>
         <defaultValue></defaultValue>
         <description>Url to fetch content to extend head </description>

--- a/omod/src/main/webapp/master-single-page-application.jsp
+++ b/omod/src/main/webapp/master-single-page-application.jsp
@@ -21,7 +21,7 @@
       window.openmrsBase = "${requestScope.openmrsBaseUrlContext}";
       window.spaBase = "${requestScope.spaBaseUrlContext}";
       window.getOpenmrsSpaBase = function() { return window.openmrsBase + window.spaBase + '/';};
-      System.import('@openmrs/esm-root-config');
+      System.import('${requestScope.spaRootConfig}');
       System.import('@openmrs/esm-styleguide');
     </script>
     <c:if test="${requestScope.spaHeadContentUrl != null }">


### PR DESCRIPTION
This adds a setting (aka Global Property) called `spa.rootConfig` that you can use to tell the server what import map module to use for the root config. It defaults to `@openmrs/esm-root-config`, to which the value was formerly hard-coded.