### PR TITLE
Fix build failures by skipping deletion of build artifacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ addons:
     packages:
       - sshpass
 deploy:
+  skip_cleanup: true
   provider: script
   script: ./deploy.sh
   on: 


### PR DESCRIPTION
Something common to recent [build failures](https://travis-ci.com/github/openmrs/openmrs-module-spa/builds) for merged PRs is the deletion of build artifacts just before running the deploy script. The deploy script is in this case possibly trying to deploy a non-existent module which then manifests in the MF site going down.

This commit adds a `skip_cleanup` flag to `.travis.yml` instructing Travis not to delete artifacts generated at build time https://docs.travis-ci.com/user/deployment-v2#cleaning-up-the-git-working-directory.


![Screenshot 2020-08-31 at 15 06 54](https://user-images.githubusercontent.com/8509731/91721387-56fe7480-eba1-11ea-8d04-2ac0cd368dba.png)
