### PR TITLE
Fix the trailing slash issue

### DIFF
--- a/omod/src/main/java/org/openmrs/module/spa/servlet/SpaServlet.java
+++ b/omod/src/main/java/org/openmrs/module/spa/servlet/SpaServlet.java
@@ -40,7 +40,7 @@ public class SpaServlet extends HttpServlet {
         File file = null;
         try {
             file = getResource(req).getFile();
-            log.info("File " + file.getAbsolutePath());
+            log.info("File {}", file.getAbsolutePath());
         } catch (IOException e) {
            log.error("Unable to get the file", e);
         }
@@ -91,12 +91,18 @@ public class SpaServlet extends HttpServlet {
     public String extractPath(String path) {
         String resourceName = path.substring(path.indexOf('/', BASE_URL.length() - 1) + 1);
 
+        // Remove the trailing slash
+        if (resourceName.length() > 0 && resourceName.charAt(resourceName.length() - 1) == '/') {
+            resourceName = resourceName.substring(0, resourceName.length() - 1);
+        }
+
         String frontedDirectoryPath = SpaModuleUtils.getFrontendDirectoryPath();
-        if (resourceName.equals("index.htm") || resourceName.isEmpty() || !resourceName.contains(".")) {
+        if (resourceName.endsWith("index.htm") || !resourceName.contains(".")) {
             resourceName = "index.html";
         }
 
         String extractedResourcePath = frontedDirectoryPath + resourceName;
+
         if (extractedResourcePath.contains("http")) {
             extractedResourcePath = "url:" + extractedResourcePath;
         }

--- a/omod/src/test/java/org/openmrs/module/spa/servlet/SpaServletTest.java
+++ b/omod/src/test/java/org/openmrs/module/spa/servlet/SpaServletTest.java
@@ -65,13 +65,14 @@ public class SpaServletTest extends BaseModuleContextSensitiveTest {
     }
 
     @Test
-    public void shouldReturnResourceExistsFalse() {
+    public void shouldReturnDefaultIndexHtmlForInvalidResource() {
         HttpServletRequest request = mock(HttpServletRequest.class);
         when(request.getPathInfo()).thenReturn("/index.htm");
 
         Resource resource = servlet.getResource(request);
         Assert.assertNotNull(resource);
-        Assert.assertFalse(resource.exists());
+        Assert.assertTrue(resource.exists());
+        Assert.assertEquals(resource.getFilename(), "index.html");
     }
 
     @Test


### PR DESCRIPTION
This PR Fixes the issue of the trailing path(i.e a request to `/openmrs/spa/login/` returns error code 500 while a request to `/openmrs/spa/login` just works fine ) by removing the trailing `/`

![image](https://user-images.githubusercontent.com/19473115/106137416-b9bd6180-617b-11eb-9936-b5378390fd4a.png)
