### PR TITLE
Add Cache-Control header to responses containing the import map

### DIFF
--- a/omod/src/main/java/org/openmrs/module/spa/servlet/SpaServlet.java
+++ b/omod/src/main/java/org/openmrs/module/spa/servlet/SpaServlet.java
@@ -71,6 +71,7 @@ public class SpaServlet extends HttpServlet {
         }
 
         response.setDateHeader("Last-Modified", file.lastModified());
+        addCacheControlHeader(request, response);
         response.setContentLength((int) file.length());
         String mimeType = getServletContext().getMimeType(file.getName());
         response.setContentType(mimeType);
@@ -95,6 +96,7 @@ public class SpaServlet extends HttpServlet {
             return;
         }
         response.setDateHeader("Last-Modified", resource.lastModified());
+        addCacheControlHeader(request, response);
         response.setContentLength((int) resource.contentLength());
         String mimeType = getServletContext().getMimeType(resource.getFilename());
         response.setContentType(mimeType);
@@ -167,6 +169,13 @@ public class SpaServlet extends HttpServlet {
             return null;
         }
         return file;
+    }
+
+    private void addCacheControlHeader(HttpServletRequest request, HttpServletResponse response) {
+        String path = request.getPathInfo();
+        if (path.endsWith("importmap.json") || path.endsWith("import-map.json")) {
+            response.setHeader("Cache-Control", "public, must-revalidate, max-age=0;");
+        }
     }
 
 }


### PR DESCRIPTION
As described [on Slack](https://openmrs.slack.com/archives/CHP5QAE5R/p1574457240260100?thread_ts=1574383200.246900&cid=CHP5QAE5R). The problem is that module-spa will serve a stale import map file even if the file has changed.