### PR TITLE
O3-3347: Follow-up; don't use mvc:annotation-driven

### DIFF
--- a/omod/src/main/java/org/openmrs/module/spa/spring/SpaBeanPostProcessor.java
+++ b/omod/src/main/java/org/openmrs/module/spa/spring/SpaBeanPostProcessor.java
@@ -1,0 +1,27 @@
+package org.openmrs.module.spa.spring;
+
+import org.openmrs.module.spa.SpaResourceConverter;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter;
+
+public class SpaBeanPostProcessor implements BeanPostProcessor, ApplicationContextAware {
+
+    private ApplicationContext applicationContext;
+
+    @Override
+    public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+        if (bean instanceof RequestMappingHandlerAdapter) {
+            RequestMappingHandlerAdapter handlerMappingAdapter = (RequestMappingHandlerAdapter) bean;
+            handlerMappingAdapter.getMessageConverters().add(0, applicationContext.getBean(SpaResourceConverter.class));
+        }
+        return bean;
+    }
+
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+        this.applicationContext = applicationContext;
+    }
+}

--- a/omod/src/main/resources/webModuleApplicationContext.xml
+++ b/omod/src/main/resources/webModuleApplicationContext.xml
@@ -18,10 +18,6 @@
     <context:annotation-config />
     <bean id="spaResourceLoader" class="org.openmrs.module.spa.SpaResourceLoader" />
     <bean class="org.openmrs.module.spa.SpaController" />
-
-    <mvc:annotation-driven>
-        <mvc:message-converters>
-            <bean class="org.openmrs.module.spa.SpaResourceConverter" />
-        </mvc:message-converters>
-    </mvc:annotation-driven>
+    <bean class="org.openmrs.module.spa.SpaResourceConverter" />
+    <bean class="org.openmrs.module.spa.spring.SpaBeanPostProcessor" />
 </beans>


### PR DESCRIPTION
This is a follow-on to #59. #59 added a section to the Spring configuration that used an `mvc:annotation-driven` element in order to register a custom `ResourceConverter`. Unfortunately, `mvc:annotation-driven` [does a lot by default](https://github.com/spring-projects/spring-framework/blob/3305485d1e6bcd5d550d1ffacc821f12028d2e36/spring-webmvc/src/main/java/org/springframework/web/servlet/config/AnnotationDrivenBeanDefinitionParser.java#L200), including registering a [a ValidatorBeanFactory](https://github.com/spring-projects/spring-framework/blob/3305485d1e6bcd5d550d1ffacc821f12028d2e36/spring-webmvc/src/main/java/org/springframework/web/servlet/config/AnnotationDrivenBeanDefinitionParser.java#L367). This interferes with the appframework which [registers its own ValidatorBeanFactory](https://github.com/openmrs/openmrs-module-appframework/blob/10512236963b59e33bf89bb16a111f1ada61ba37/api/src/main/resources/moduleApplicationContext.xml#L7), leading to the application failing.

This PR works around that by using a `BeanPostProcessor` to register the message converter with the `RequestMappingHandlerAdapter`.