### PR TITLE
O3-4395: Fix caching for non-static configuration files

### DIFF
--- a/omod/src/main/java/org/openmrs/module/spa/SpaController.java
+++ b/omod/src/main/java/org/openmrs/module/spa/SpaController.java
@@ -83,7 +83,7 @@ public class SpaController {
      * This controller method should handle every other URL. We assume that the correct response is the index.html, i.e.,
      * the single page.
      */
-    @RequestMapping({ "", "/**/{filename:.?(?!.*\\.[^.]*$).*$}", "*.html", "*.htm"})
+    @RequestMapping({ "/", "/**/{filename:.?(?!.*\\.[^.]*$).*$}", "*.html", "*.htm"})
     public ResponseEntity<Resource> getSinglePage() {
         Resource resource = resourceLoader.getResource("/index.html");
         if (resource.exists()) {

--- a/omod/src/main/java/org/openmrs/module/spa/SpaController.java
+++ b/omod/src/main/java/org/openmrs/module/spa/SpaController.java
@@ -39,32 +39,8 @@ public class SpaController {
     }
 
     /**
-     * This controller method handles importmap.json, routes.registry.json and service-worker.js, ensuring that they are
-     * sent with no-cache and must-revalidate headers.
-     * <p/>
-     * Note that if you are using the {@code --hash-import-map} feature of the {@code assemble} command, your distro's
-     * importmap will look like importmap.&lt;hash&gt;.json and <em>should</em> be cached.
-     */
-    @RequestMapping("/{filename:(?:importmap|routes\\.registry)\\.json|service-worker\\.js}")
-    public ResponseEntity<Resource> getStaticFileWithoutCacheHeaders(@PathVariable String filename) {
-        FileSystemResource resource = (FileSystemResource) resourceLoader.getResource("/" + filename);
-        if (resource.exists()) {
-            MediaType mediaType = filename.endsWith(".js") ? MediaType.parseMediaType("text/javascript") : MediaType.APPLICATION_JSON;
-
-            return ResponseEntity.ok()
-                    .cacheControl(CacheControl.noCache().mustRevalidate())
-                    .header("Expires", "0")
-                    .contentType(mediaType)
-                    .body(resource);
-        } else {
-            return ResponseEntity.notFound().build();
-        }
-    }
-
-    /**
-     * This controller method attempts to handle any file with an extension that is not .html or .htm and resolve it to
-     * a file. All resources return in this way should be cached for as long as possible. Technically that's not what
-     * we do here, but 6 months is probably long enough.
+     * This controller method attempts to handle any request for a URL that has a file extension other than .htm or .html.
+     * It attempts to resolve this URL to a file using the resource loader.
      */
     @RequestMapping(value = "/**/{filename:.*\\.(?!html?)[^.]+$}")
     public ResponseEntity<Resource> getStaticFile(HttpServletRequest request) {
@@ -95,38 +71,28 @@ public class SpaController {
             }
 
             return ResponseEntity.ok()
-                    .cacheControl(CacheControl.maxAge(180, TimeUnit.DAYS))
-                    .headers(headers ->
-                            headers.setExpires(Instant.now().plus(180, ChronoUnit.DAYS))
-                    )
+                    .cacheControl(CacheControl.noCache().mustRevalidate())
                     .contentType(mediaType)
                     .body(resource);
         } else {
-            return ResponseEntity.notFound().build();
+            return ResponseEntity.notFound().cacheControl(CacheControl.noCache().mustRevalidate()).build();
         }
     }
 
     /**
-     * This controller method should handle everything else, and we assume that the correct response is the index.html
-     * file. Like {@link #getStaticFileWithoutCacheHeaders(String)}, this attempts to force the client to always reload
-     * this resource.
+     * This controller method should handle every other URL. We assume that the correct response is the index.html, i.e.,
+     * the single page.
      */
-    @RequestMapping({ "/", "/**/{filename:.?(?!.*\\.[^.]*$).*$}", "*.html", "*.htm"})
+    @RequestMapping({ "", "/**/{filename:.?(?!.*\\.[^.]*$).*$}", "*.html", "*.htm"})
     public ResponseEntity<Resource> getSinglePage() {
         Resource resource = resourceLoader.getResource("/index.html");
         if (resource.exists()) {
             return ResponseEntity.ok()
                     .cacheControl(CacheControl.noCache().mustRevalidate())
-                    .header("Expires", "0")
                     .contentType(MediaType.TEXT_HTML)
                     .body(resource);
         } else {
-            return ResponseEntity.notFound().build();
+            return ResponseEntity.notFound().cacheControl(CacheControl.noCache().mustRevalidate()).build();
         }
-    }
-
-    @RequestMapping("")
-    public ResponseEntity<Resource> index(HttpServletRequest request) {
-        return ResponseEntity.status(HttpStatus.MOVED_PERMANENTLY).location(URI.create(request.getContextPath() + "/spa/")).build();
     }
 }

--- a/omod/src/main/java/org/openmrs/module/spa/SpaController.java
+++ b/omod/src/main/java/org/openmrs/module/spa/SpaController.java
@@ -95,4 +95,9 @@ public class SpaController {
             return ResponseEntity.notFound().cacheControl(CacheControl.noCache().mustRevalidate()).build();
         }
     }
+
+    @RequestMapping("")
+    public ResponseEntity<Resource> index(HttpServletRequest request) {
+        return ResponseEntity.status(HttpStatus.MOVED_PERMANENTLY).location(URI.create(request.getContextPath() + "/spa/")).build();
+    }
 }

--- a/omod/src/main/java/org/openmrs/module/spa/spring/SpaBeanPostProcessor.java
+++ b/omod/src/main/java/org/openmrs/module/spa/spring/SpaBeanPostProcessor.java
@@ -5,6 +5,7 @@ import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
+import org.springframework.lang.NonNull;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter;
 
 public class SpaBeanPostProcessor implements BeanPostProcessor, ApplicationContextAware {
@@ -12,7 +13,7 @@ public class SpaBeanPostProcessor implements BeanPostProcessor, ApplicationConte
     private ApplicationContext applicationContext;
 
     @Override
-    public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+    public Object postProcessAfterInitialization(@NonNull Object bean, @NonNull String beanName) throws BeansException {
         if (bean instanceof RequestMappingHandlerAdapter) {
             RequestMappingHandlerAdapter handlerMappingAdapter = (RequestMappingHandlerAdapter) bean;
             handlerMappingAdapter.getMessageConverters().add(0, applicationContext.getBean(SpaResourceConverter.class));
@@ -21,7 +22,7 @@ public class SpaBeanPostProcessor implements BeanPostProcessor, ApplicationConte
     }
 
     @Override
-    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+    public void setApplicationContext(@NonNull ApplicationContext applicationContext) throws BeansException {
         this.applicationContext = applicationContext;
     }
 }


### PR DESCRIPTION
Addresses [O3-4395](https://openmrs.atlassian.net/browse/O3-4395), by sending `no-cache, must-revalidate` for every response. This should ensure that the client needs to re-validate each request, which should result in a relatively cheap 304 response.

[O3-4395]: https://openmrs.atlassian.net/browse/O3-4395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ